### PR TITLE
FOR-konformer Namespace

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,17 +1,18 @@
 <?php
 
-use YFormExport\Export;
+use FriendsOfRedaxo\YFormExport\Export;
+use FriendsOfRedaxo\YFormExport\ExtensionPoints;
 
 if (rex::isBackend() && 'index.php?page=yform/manager/data_edit' === rex_url::currentBackendPage()) {
     /**
      * register EP, attach export button.
      */
-    \rex_extension::register('YFORM_DATA_LIST_LINKS', 'YFormExport\ExtensionPoints::YFORM_DATA_LIST_LINKS');
+    \rex_extension::register('YFORM_DATA_LIST_LINKS', ExtensionPoints::YFORM_DATA_LIST_LINKS(...));
 
     new Export();
 
     /**
      * register EP, attach messages.
      */
-    \rex_extension::register('YFORM_MANAGER_DATA_PAGE_HEADER', 'YFormExport\ExtensionPoints::YFORM_MANAGER_DATA_PAGE_HEADER');
+    \rex_extension::register('YFORM_MANAGER_DATA_PAGE_HEADER', ExtensionPoints::YFORM_MANAGER_DATA_PAGE_HEADER(...));
 }

--- a/boot.php
+++ b/boot.php
@@ -2,17 +2,18 @@
 
 use FriendsOfRedaxo\YFormExport\Export;
 use FriendsOfRedaxo\YFormExport\ExtensionPoints;
+use rex_extension;
 
 if (rex::isBackend() && 'index.php?page=yform/manager/data_edit' === rex_url::currentBackendPage()) {
     /**
      * register EP, attach export button.
      */
-    \rex_extension::register('YFORM_DATA_LIST_LINKS', ExtensionPoints::YFORM_DATA_LIST_LINKS(...));
+    rex_extension::register('YFORM_DATA_LIST_LINKS', ExtensionPoints::YFORM_DATA_LIST_LINKS(...));
 
     new Export();
 
     /**
      * register EP, attach messages.
      */
-    \rex_extension::register('YFORM_MANAGER_DATA_PAGE_HEADER', ExtensionPoints::YFORM_MANAGER_DATA_PAGE_HEADER(...));
+    rex_extension::register('YFORM_MANAGER_DATA_PAGE_HEADER', ExtensionPoints::YFORM_MANAGER_DATA_PAGE_HEADER(...));
 }

--- a/lib/Export.php
+++ b/lib/Export.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace YFormExport;
+namespace FriendsOfRedaxo\YFormExport;
 
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;

--- a/lib/Export.php
+++ b/lib/Export.php
@@ -16,7 +16,6 @@ use rex_string;
 use rex_yform_manager_field;
 use rex_yform_manager_table;
 use rex_yform_value_be_manager_relation;
-
 use rex_yform_value_choice;
 
 use function array_key_exists;

--- a/lib/ExtensionPoints.php
+++ b/lib/ExtensionPoints.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace YFormExport;
+namespace FriendsOfRedaxo\YFormExport;
 
 use rex;
 use rex_exception;


### PR DESCRIPTION
Vorschlag: Umstellung des Namespace auf den FOR-konformen Prefix `FriendsOfRedaxo`

- Namespace `YFormExport`-> `FriendsOfRedaxo\YFormExport`
- Klasse `YFormExport\Export`-> `FriendsOfRedaxo\YFormExport\Export`
- Klasse `YFormExport\ExtensionPoints`-> `FriendsOfRedaxo\YFormExport\ExtensionPoints`

Nebenbei in der Boot.php die Schreibweise der Callbacks geändert in die First Class Callable Syntax
- `rex_extension::register('YFORM_DATA_LIST_LINKS', ExtensionPoints::YFORM_DATA_LIST_LINKS(...));`
- `rex_extension::register('YFORM_MANAGER_DATA_PAGE_HEADER', ExtensionPoints::YFORM_MANAGER_DATA_PAGE_HEADER(...))`

PHP-CS-FIXER über die drei Dateien geschickt.

Da es kein Changelog gibt, habe ich dort auch nichts eingetragen.

Kurz getestet (installiert, Export-Button vorhanden, Export funktioniert)